### PR TITLE
Pass examples in stri_sub.Rd

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <version>1.2-SNAPSHOT</version>
 
   <properties>
-    <renjin.version>0.8.2472</renjin.version>
+    <renjin.version>0.8.2473</renjin.version>
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <version>1.2-SNAPSHOT</version>
 
   <properties>
-    <renjin.version>0.8.2467</renjin.version>
+    <renjin.version>0.8.2472</renjin.version>
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
   </properties>

--- a/renjin/org/renjin/cran/stringi/ColumnIntVector.java
+++ b/renjin/org/renjin/cran/stringi/ColumnIntVector.java
@@ -1,0 +1,58 @@
+/**
+ * Renjin : JVM-based interpreter for the R language for the statistical analysis
+ * Copyright © 2010-2016 BeDataDriven Groep B.V. and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, a copy is available at
+ * https://www.gnu.org/licenses/gpl-2.0.txt
+ */
+package org.renjin.cran.stringi;
+
+import org.renjin.primitives.matrix.Matrix;
+import org.renjin.sexp.AttributeMap;
+import org.renjin.sexp.IntVector;
+import org.renjin.sexp.SEXP;
+
+/**
+ * Wrapper class to present a column from a matrix as a vector.
+ */
+public class ColumnIntVector extends IntVector {
+  private Matrix matrix;
+  private int col;
+
+  public ColumnIntVector(Matrix matrix, int col) {
+    this.matrix = matrix;
+    this.col = col;
+  }
+
+  @Override
+  public boolean isConstantAccessTime() {
+    return matrix.getVector().isConstantAccessTime();
+  }
+
+  @Override
+  public int length() {
+    return matrix.getNumRows();
+  }
+
+  @Override
+  public int getElementAsInt(int i) {
+    return matrix.getElementAsInt(i, col);
+  }
+
+  @Override
+  protected SEXP cloneWithNewAttributes(AttributeMap attributes) {
+    return new ColumnIntVector(matrix, col);
+  }
+
+}

--- a/renjin/org/renjin/cran/stringi/stringi.java
+++ b/renjin/org/renjin/cran/stringi/stringi.java
@@ -563,9 +563,9 @@ public class stringi {
         }
         int previousStart = 0;
         int beginIndex = matcher.span(element, previousStart, UnicodeSet.SpanCondition.NOT_CONTAINED);
-        if (0 < beginIndex) {
+        if (-1 < beginIndex) {
           final List<Range<Integer>> occurrences = new LinkedList<>();
-          while (previousStart < element.length()) {
+          while (previousStart < element.length() && beginIndex < element.length()) {
             final int endIndex = matcher.span(element, beginIndex, UnicodeSet.SpanCondition.CONTAINED);
             if (is_merging) {
               occurrences.add(Range.closedOpen(beginIndex, endIndex));

--- a/renjin/org/renjin/cran/stringi/stringi.java
+++ b/renjin/org/renjin/cran/stringi/stringi.java
@@ -311,18 +311,212 @@ public class stringi {
   public static SEXP stri_extract_first_boundaries(SEXP s1, SEXP s2) { throw new EvalException("TODO"); }
   public static SEXP stri_extract_last_boundaries(SEXP s1, SEXP s2) { throw new EvalException("TODO"); }
   public static SEXP stri_extract_all_boundaries(SEXP s1, SEXP s2, SEXP s3, SEXP s4) { throw new EvalException("TODO"); }
-  public static SEXP stri_extract_first_charclass(SEXP s1, SEXP s2) { throw new EvalException("TODO"); }
-  public static SEXP stri_extract_last_charclass(SEXP s1, SEXP s2) { throw new EvalException("TODO"); }
-  public static SEXP stri_extract_all_charclass(SEXP s1, SEXP s2, SEXP s3, SEXP s4, SEXP s5) { throw new EvalException("TODO"); }
-  public static SEXP stri_extract_first_coll(SEXP s1, SEXP s2, SEXP s3) { throw new EvalException("TODO"); }
-  public static SEXP stri_extract_last_coll(SEXP s1, SEXP s2, SEXP s3) { throw new EvalException("TODO"); }
-  public static SEXP stri_extract_all_coll(SEXP s1, SEXP s2, SEXP s3, SEXP s4, SEXP s5) { throw new EvalException("TODO"); }
-  public static SEXP stri_extract_first_fixed(SEXP s1, SEXP s2, SEXP s3) { throw new EvalException("TODO"); }
-  public static SEXP stri_extract_last_fixed(SEXP s1, SEXP s2, SEXP s3) { throw new EvalException("TODO"); }
-  public static SEXP stri_extract_all_fixed(SEXP s1, SEXP s2, SEXP s3, SEXP s4, SEXP s5) { throw new EvalException("TODO"); }
-  public static SEXP stri_extract_first_regex(SEXP s1, SEXP s2, SEXP s3) { throw new EvalException("TODO"); }
-  public static SEXP stri_extract_last_regex(SEXP s1, SEXP s2, SEXP s3) { throw new EvalException("TODO"); }
-  public static SEXP stri_extract_all_regex(SEXP s1, SEXP s2, SEXP s3, SEXP s4, SEXP s5) { throw new EvalException("TODO"); }
+  public static SEXP stri_extract_first_charclass(SEXP str, SEXP pattern) {
+    return __extract_firstlast_charclass(str, pattern, ReplaceType.FIRST);
+  }
+  public static SEXP stri_extract_last_charclass(SEXP str, SEXP pattern) {
+    return __extract_firstlast_charclass(str, pattern, ReplaceType.LAST);
+  }
+  public static SEXP stri_extract_all_charclass(SEXP str, SEXP pattern, SEXP merge, SEXP simplify, SEXP omit_no_match) {
+    final boolean is_merging = ((AtomicVector) merge).getElementAsLogical(0).toBooleanStrict();
+    final boolean omits_not_found = ((AtomicVector) omit_no_match).getElementAsLogical(0).toBooleanStrict();
+    final int length = __recycling_rule(true, str, pattern);
+    final StringVector[] result = new StringVector[length];
+    final StringVector strings = __ensure_length(length, stri_prepare_arg_string(str, "str"));
+    final StringVector patterns = __ensure_length(length, stri_prepare_arg_string(pattern, "pattern"));
+
+    String lastPattern = null;
+    UnicodeSet matcher = null;
+    for (int i = 0; i < length; i++) {
+      if (strings.isElementNA(i) || patterns.isElementNA(i)) {
+        result[i] = StringVector.valueOf(StringVector.NA);
+      } else {
+        final String element = strings.getElementAsString(i);
+        final String separatorPattern = patterns.getElementAsString(i);
+        if (!separatorPattern.equals(lastPattern)) {
+          lastPattern = separatorPattern;
+          matcher = new UnicodeSet(separatorPattern);
+        }
+        int previousStart = 0;
+        int beginIndex = matcher.span(element, previousStart, UnicodeSet.SpanCondition.NOT_CONTAINED);
+        if (-1 < beginIndex) {
+          final List<Range<Integer>> occurrences = new LinkedList<>();
+          while (previousStart < element.length() && beginIndex < element.length()) {
+            final int endIndex = matcher.span(element, beginIndex, UnicodeSet.SpanCondition.CONTAINED);
+            if (is_merging) {
+              occurrences.add(Range.closedOpen(beginIndex, endIndex));
+            } else {
+              for (int k = beginIndex; k < endIndex; k++) {
+                occurrences.add(Range.closedOpen(k, k + 1));
+              }
+            }
+            previousStart = endIndex;
+            beginIndex = matcher.span(element, previousStart, UnicodeSet.SpanCondition.NOT_CONTAINED);
+          }
+          final String[] values = new String[occurrences.size()];
+          int j = 0;
+          for (Range<Integer> entry : occurrences) {
+            values[j++] = element.substring(entry.lowerEndpoint(), entry.upperEndpoint());
+          }
+          result[i] = new StringArrayVector(values);
+        } else {
+          result[i] = __string_vector_NA(omits_not_found ? 0 : 1);
+        }
+      }
+    }
+
+    return __simplify_when_required(new ListVector(result), simplify, IntVector.valueOf(0));
+  }
+  public static SEXP stri_extract_first_coll(SEXP str, SEXP pattern, SEXP opts_collator) {
+    return __extract_firstlast_coll(str, pattern, opts_collator, ReplaceType.FIRST);
+  }
+  public static SEXP stri_extract_last_coll(SEXP str, SEXP pattern, SEXP opts_collator) {
+    return __extract_firstlast_coll(str, pattern, opts_collator, ReplaceType.LAST);
+  }
+  public static SEXP stri_extract_all_coll(SEXP str, SEXP pattern, SEXP simplify, SEXP omit_no_match, SEXP opts_collator) {
+    final RuleBasedCollator collator = __open_collator(opts_collator);
+    final boolean omits_not_found = ((AtomicVector) omit_no_match).getElementAsLogical(0).toBooleanStrict();
+    final int length = __recycling_rule(true, str, pattern);
+    final StringVector[] result = new StringVector[length];
+    final StringVector strings = __ensure_length(length, stri_prepare_arg_string(str, "str"));
+    final StringVector patterns = __ensure_length(length, stri_prepare_arg_string(pattern, "pattern"));
+    
+    String lastPattern = null;
+    StringSearch matcher = null;
+    for (int i = 0; i < length; i++) {
+      if (strings.isElementNA(i) || patterns.isElementNA(i) || patterns.getElementAsString(i).length() <= 0) {
+        if (!patterns.isElementNA(i) && patterns.getElementAsString(i).length() <= 0) {
+          Native.currentContext().warn("empty search patterns are not supported");
+        }
+        result[i] = StringVector.valueOf(StringVector.NA);
+      } else if (strings.getElementAsString(i).length() <= 0) {
+        result[i] = __string_vector_NA(omits_not_found ? 0 : 1);
+      } else {
+        final String element = strings.getElementAsString(i);
+        final String separatorPattern = patterns.getElementAsString(i);
+        if (separatorPattern.equals(lastPattern)) {
+          matcher.setTarget(new StringCharacterIterator(element));
+        } else {
+          lastPattern = separatorPattern;
+          matcher = new StringSearch(separatorPattern, new StringCharacterIterator(element), collator);
+        }
+        matcher.reset();
+        int beginIndex = matcher.first();
+        if (beginIndex == StringSearch.DONE) {
+          result[i] = __string_vector_NA(omits_not_found ? 0 : 1);
+        } else {
+          final List<Range<Integer>> occurrences = new LinkedList<>();
+          while (beginIndex != StringSearch.DONE) {
+            occurrences.add(Range.closedOpen(beginIndex, beginIndex + matcher.getMatchLength()));
+            beginIndex = matcher.next();
+          }
+          final String[] values = new String[occurrences.size()];
+          int j = 0;
+          for (Range<Integer> entry : occurrences) {
+            values[j++] = element.substring(entry.lowerEndpoint(), entry.upperEndpoint());
+          }
+          result[i] = new StringArrayVector(values);
+        }
+      }
+    }
+
+    return __simplify_when_required(new ListVector(result), simplify, IntVector.valueOf(0));
+  }
+  public static SEXP stri_extract_first_fixed(SEXP str, SEXP pattern, SEXP opts_fixed) {
+    return __extract_firstlast_fixed(str, pattern, opts_fixed, ReplaceType.FIRST);
+  }
+  public static SEXP stri_extract_last_fixed(SEXP str, SEXP pattern, SEXP opts_fixed) {
+    return __extract_firstlast_fixed(str, pattern, opts_fixed, ReplaceType.LAST);
+  }
+  public static SEXP stri_extract_all_fixed(SEXP str, SEXP pattern, SEXP simplify, SEXP omit_no_match, SEXP opts_fixed) {
+    final int flags = __fixed_flags(opts_fixed, true);
+    final boolean is_insensitive = (flags & Pattern.CASE_INSENSITIVE) > 0;
+    final boolean omits_not_found = ((AtomicVector) omit_no_match).getElementAsLogical(0).toBooleanStrict();
+    final int length = __recycling_rule(true, str, pattern);
+    final StringVector[] result = new StringVector[length];
+    final StringVector strings = __ensure_length(length, stri_prepare_arg_string(str, "str"));
+    final StringVector patterns = __ensure_length(length, stri_prepare_arg_string(pattern, "pattern"));
+
+    for (int i = 0; i < length; i++) {
+      if (strings.isElementNA(i) || patterns.isElementNA(i) || patterns.getElementAsString(i).length() <= 0) {
+        if (!patterns.isElementNA(i) && patterns.getElementAsString(i).length() <= 0) {
+          Native.currentContext().warn("empty search patterns are not supported");
+        }
+        result[i] = StringVector.valueOf(StringVector.NA);
+      } else if (strings.getElementAsString(i).length() <= 0) {
+        result[i] = __string_vector_NA(omits_not_found ? 0 : 1);
+      } else {
+        final String element = strings.getElementAsString(i);
+        final String separatorPattern = patterns.getElementAsString(i);
+        final int patternLength = separatorPattern.length();
+        final String patternNormalized = is_insensitive ? separatorPattern.toUpperCase() : separatorPattern;
+        final String elementNormalized = is_insensitive ? element.toUpperCase() : element;
+        int previousStart = 0;
+        int beginIndex = elementNormalized.indexOf(patternNormalized);
+        if (-1 < beginIndex) {
+          final List<Range<Integer>> occurrences = new LinkedList<>();
+          while (-1 < beginIndex) {
+            occurrences.add(Range.closedOpen(beginIndex, beginIndex + patternLength));
+            previousStart = beginIndex + patternLength;
+            beginIndex = elementNormalized.indexOf(patternNormalized, previousStart);
+          }
+          final String[] values = new String[occurrences.size()];
+          int j = 0;
+          for (Range<Integer> entry : occurrences) {
+            values[j++] = element.substring(entry.lowerEndpoint(), entry.upperEndpoint());
+          }
+          result[i] = new StringArrayVector(values);
+        } else {
+          result[i] = __string_vector_NA(omits_not_found ? 0 : 1);
+        }
+      }
+    }
+
+    return __simplify_when_required(new ListVector(result), simplify, IntVector.valueOf(0));
+  }
+  public static SEXP stri_extract_first_regex(SEXP str, SEXP pattern, SEXP opts_regex) {
+    return __extract_firstlast_regex(str, pattern, opts_regex, ReplaceType.FIRST);
+  }
+  public static SEXP stri_extract_last_regex(SEXP str, SEXP pattern, SEXP opts_regex) {
+    return __extract_firstlast_regex(str, pattern, opts_regex, ReplaceType.LAST);
+  }
+  public static SEXP stri_extract_all_regex(SEXP str, SEXP pattern, SEXP simplify, SEXP omit_no_match, SEXP opts_regex) {
+    final int flags = __regex_flags(opts_regex);
+    final boolean omits_not_found = ((AtomicVector) omit_no_match).getElementAsLogical(0).toBooleanStrict();
+    final int length = __recycling_rule(true, str, pattern);
+    final StringVector[] result = new StringVector[length];
+    final StringVector strings = __ensure_length(length, stri_prepare_arg_string(str, "str"));
+    final StringVector patterns = __ensure_length(length, stri_prepare_arg_string(pattern, "pattern"));
+
+    for (int i = 0; i < length; i++) {
+      if (strings.isElementNA(i) || patterns.isElementNA(i) || patterns.getElementAsString(i).length() <= 0) {
+        if (!patterns.isElementNA(i) && patterns.getElementAsString(i).length() <= 0) {
+          Native.currentContext().warn("empty search patterns are not supported");
+        }
+        result[i] = StringVector.valueOf(StringVector.NA);
+      } else {
+        final String element = strings.getElementAsString(i);
+        final String normalizedPattern = __binary_properties_to_Java(patterns.getElementAsString(i));
+        final Matcher matcher = Pattern.compile(normalizedPattern, flags).matcher(element);
+        final LinkedList<Range<Integer>> occurrences = new LinkedList<>();
+        while (matcher.find()) {
+          occurrences.add(Range.closedOpen(matcher.start(), matcher.end()));
+        }
+        if (occurrences.size() <= 0) {
+          result[i] = __string_vector_NA(omits_not_found ? 0 : 1);
+        } else {
+          final String[] values = new String[occurrences.size()];
+          int j = 0;
+          for (Range<Integer> entry : occurrences) {
+            values[j++] = element.substring(entry.lowerEndpoint(), entry.upperEndpoint());
+          }
+          result[i] = new StringArrayVector(values);
+        }
+      }
+    }
+
+    return __simplify_when_required(new ListVector(result), simplify, IntVector.valueOf(0));
+  }
   public static SEXP stri_flatten(SEXP str, SEXP collapse) {
     final StringVector collapsers = stri_prepare_arg_string(collapse, "collapse");
     if (collapsers.isElementNA(0)) {
@@ -1657,7 +1851,7 @@ public class stringi {
     }
     return builder;
   }
-  private static SEXP __string_vector_NA(final int length) {
+  private static StringVector __string_vector_NA(final int length) {
     final StringVector.Builder builder = StringVector.newBuilder();
     for (int j = 0; j < length; j++) {
       builder.addNA();
@@ -2271,5 +2465,178 @@ public class stringi {
     final StringVector names = new StringArrayVector(new String[] { "start", "end" });
     builder.setColNames(names);
     return builder.build();
+  }
+  private static SEXP __extract_firstlast_charclass(SEXP str, SEXP pattern, ReplaceType replaces) {
+    final int length = __recycling_rule(true, str, pattern);
+    final String[] result = new String[length];
+    final StringVector strings = __ensure_length(length, stri_prepare_arg_string(str, "str"));
+    final StringVector patterns = __ensure_length(length, stri_prepare_arg_string(pattern, "pattern"));
+
+    String lastPattern = null;
+    UnicodeSet matcher = null;
+    for (int i = 0; i < length; i++) {
+      if (strings.isElementNA(i) || patterns.isElementNA(i)) {
+        result[i] = StringVector.NA;
+      } else {
+        final String element = strings.getElementAsString(i);
+        final String separatorPattern = patterns.getElementAsString(i);
+        if (!separatorPattern.equals(lastPattern)) {
+          lastPattern = separatorPattern;
+          matcher = new UnicodeSet(separatorPattern);
+        }
+        if (replaces.isFirst()) {
+          final int beginIndex = matcher.span(element, UnicodeSet.SpanCondition.NOT_CONTAINED);
+          if (-1 < beginIndex) {
+            result[i] = element.substring(beginIndex, beginIndex + 1);
+          } else {
+            result[i] = StringVector.NA;
+          }
+        } else if (replaces.isLast()) {
+          final int beginIndex = matcher.spanBack(element, UnicodeSet.SpanCondition.NOT_CONTAINED);
+          if (-1 < beginIndex) {
+            result[i] = element.substring(beginIndex - 1, beginIndex);
+          } else {
+            result[i] = StringVector.NA;
+          }
+        } else {
+          result[i] = StringVector.NA;
+        }
+      }
+    }
+
+    return new StringArrayVector(result);
+  }
+  private static SEXP __extract_firstlast_coll(SEXP str, SEXP pattern, SEXP opts_collator, ReplaceType replaces) {
+    final RuleBasedCollator collator = __open_collator(opts_collator);
+    final int length = __recycling_rule(true, str, pattern);
+    final String[] result = new String[length];
+    final StringVector strings = __ensure_length(length, stri_prepare_arg_string(str, "str"));
+    final StringVector patterns = __ensure_length(length, stri_prepare_arg_string(pattern, "pattern"));
+
+    String lastPattern = null;
+    StringSearch matcher = null;
+    for (int i = 0; i < length; i++) {
+      if (strings.isElementNA(i) || patterns.isElementNA(i) || patterns.getElementAsString(i).length() <= 0) {
+        if (!patterns.isElementNA(i) && patterns.getElementAsString(i).length() <= 0) {
+          Native.currentContext().warn("empty search patterns are not supported");
+        }
+        result[i] = StringVector.NA;
+      } else if (strings.getElementAsString(i).length() <= 0) {
+        result[i] = StringVector.NA;
+      } else {
+        final String element = strings.getElementAsString(i);
+        final String separatorPattern = patterns.getElementAsString(i);
+        if (separatorPattern.equals(lastPattern)) {
+          matcher.setTarget(new StringCharacterIterator(element));
+        } else {
+          lastPattern = separatorPattern;
+          matcher = new StringSearch(separatorPattern, new StringCharacterIterator(element), collator);
+        }
+        matcher.reset();
+        if (replaces.isFirst()) {
+          final int beginIndex = matcher.first();
+          if (beginIndex == StringSearch.DONE) {
+            result[i] = StringVector.NA;
+          } else {
+            result[i] = element.substring(beginIndex, beginIndex + matcher.getMatchLength());
+          }
+        } else if (replaces.isLast()) {
+          final int beginIndex = matcher.last();
+          if (beginIndex == StringSearch.DONE) {
+            result[i] = StringVector.NA;
+          } else {
+            result[i] = element.substring(beginIndex, beginIndex + matcher.getMatchLength());
+          }
+        } else {
+          result[i] = StringVector.NA;
+        }
+      }
+    }
+
+    return new StringArrayVector(result);
+  }
+  private static SEXP __extract_firstlast_fixed(SEXP str, SEXP pattern, SEXP opts_fixed, ReplaceType replaces) {
+    final int flags = __fixed_flags(opts_fixed, true);
+    final boolean is_insensitive = (flags & Pattern.CASE_INSENSITIVE) > 0;
+    final int length = __recycling_rule(true, str, pattern);
+    final String[] result = new String[length];
+    final StringVector strings = __ensure_length(length, stri_prepare_arg_string(str, "str"));
+    final StringVector patterns = __ensure_length(length, stri_prepare_arg_string(pattern, "pattern"));
+
+    for (int i = 0; i < length; i++) {
+      if (strings.isElementNA(i) || patterns.isElementNA(i) || patterns.getElementAsString(i).length() <= 0) {
+        if (!patterns.isElementNA(i) && patterns.getElementAsString(i).length() <= 0) {
+          Native.currentContext().warn("empty search patterns are not supported");
+        }
+        result[i] = StringVector.NA;
+      } else if (strings.getElementAsString(i).length() <= 0) {
+        result[i] = StringVector.NA;
+      } else {
+        final String element = strings.getElementAsString(i);
+        final String separatorPattern = patterns.getElementAsString(i);
+        final int patternLength = separatorPattern.length();
+        final String patternNormalized = is_insensitive ? separatorPattern.toUpperCase() : separatorPattern;
+        final String elementNormalized = is_insensitive ? element.toUpperCase() : element;
+        if (replaces.isFirst()) {
+          final int beginIndex = elementNormalized.indexOf(patternNormalized);
+          if (-1 < beginIndex) {
+            result[i] = element.substring(beginIndex, beginIndex + patternLength);
+          } else {
+            result[i] = StringVector.NA;
+          }
+        } else if (replaces.isLast()) {
+          final int beginIndex = elementNormalized.lastIndexOf(patternNormalized);
+          if (-1 < beginIndex) {
+            result[i] = element.substring(beginIndex, beginIndex + patternLength);
+          } else {
+            result[i] = StringVector.NA;
+          }
+        } else {
+          result[i] = StringVector.NA;
+        }
+      }
+    }
+
+    return null;
+  }
+  private static SEXP __extract_firstlast_regex(SEXP str, SEXP pattern, SEXP opts_regex, ReplaceType replaces) {
+    final int flags = __regex_flags(opts_regex);
+    final int length = __recycling_rule(true, str, pattern);
+    final String[] result = new String[length];
+    final StringVector strings = __ensure_length(length, stri_prepare_arg_string(str, "str"));
+    final StringVector patterns = __ensure_length(length, stri_prepare_arg_string(pattern, "pattern"));
+
+    for (int i = 0; i < length; i++) {
+      if (strings.isElementNA(i) || patterns.isElementNA(i) || patterns.getElementAsString(i).length() <= 0) {
+        if (!patterns.isElementNA(i) && patterns.getElementAsString(i).length() <= 0) {
+          Native.currentContext().warn("empty search patterns are not supported");
+        }
+        result[i] = StringVector.NA;
+      } else {
+        final String element = strings.getElementAsString(i);
+        final String normalizedPattern = __binary_properties_to_Java(patterns.getElementAsString(i));
+        final Matcher matcher = Pattern.compile(normalizedPattern, flags).matcher(element);
+        boolean found = matcher.find();
+        if (found) {
+          if (replaces.isFirst()) {
+            result[i] = element.substring(matcher.start(), matcher.end());
+          } else if (replaces.isLast()) {
+            int start = matcher.start();
+            int end = matcher.end();
+            while (matcher.find()) {
+              start = matcher.start();
+              end = matcher.end();
+            }
+            result[i] = element.substring(start, end);
+          } else {
+            result[i] = StringVector.NA;
+          }
+        } else {
+          result[i] = StringVector.NA;
+        }
+      }
+    }
+
+    return new StringArrayVector(result);
   }
 }

--- a/renjin/org/renjin/cran/stringi/stringi.java
+++ b/renjin/org/renjin/cran/stringi/stringi.java
@@ -2597,7 +2597,7 @@ public class stringi {
       }
     }
 
-    return null;
+    return new StringArrayVector(result);
   }
   private static SEXP __extract_firstlast_regex(SEXP str, SEXP pattern, SEXP opts_regex, ReplaceType replaces) {
     final int flags = __regex_flags(opts_regex);

--- a/renjin/org/renjin/cran/stringi/stringi.java
+++ b/renjin/org/renjin/cran/stringi/stringi.java
@@ -16,6 +16,7 @@ import java.util.regex.Pattern;
 
 import org.renjin.eval.EvalException;
 import org.renjin.primitives.Native;
+import org.renjin.primitives.Types;
 import org.renjin.primitives.matrix.IntMatrixBuilder;
 import org.renjin.primitives.packaging.DllInfo;
 import org.renjin.primitives.packaging.DllSymbol;
@@ -33,7 +34,6 @@ import org.renjin.sexp.ListVector;
 import org.renjin.sexp.Logical;
 import org.renjin.sexp.LogicalArrayVector;
 import org.renjin.sexp.LogicalVector;
-import org.renjin.sexp.Null;
 import org.renjin.sexp.SEXP;
 import org.renjin.sexp.StringArrayVector;
 import org.renjin.sexp.StringVector;
@@ -493,7 +493,7 @@ public class stringi {
     return new LogicalArrayVector(result);
   }
   public static SEXP stri_join(SEXP strlist, SEXP sep, SEXP collapse, SEXP ignore_null) {
-    if (Null.INSTANCE.equals(collapse)) {
+    if (Types.isNull(collapse)) {
       return __join_no_collapse(strlist, sep, ignore_null);
     } else {
       final boolean ignore_empty = ((AtomicVector) ignore_null).getElementAsLogical(0).toBooleanStrict();
@@ -1712,7 +1712,7 @@ public class stringi {
     return new StringArrayVector(result);
   }
   public static SEXP stri_trans_tolower(SEXP str, SEXP locale) {
-    final Locale language = Null.INSTANCE.equals(locale) ? Locale.getDefault() : Locale.forLanguageTag(locale.asString());
+    final Locale language = Types.isNull(locale) ? Locale.getDefault() : Locale.forLanguageTag(locale.asString());
     final int length = str.length();
     final String[] result = new String[length];
     final StringVector strings = stri_prepare_arg_string(str, "str");
@@ -1732,7 +1732,7 @@ public class stringi {
     return new StringArrayVector(result);
   }
   public static SEXP stri_trans_toupper(SEXP str, SEXP locale) {
-    final Locale language = Null.INSTANCE.equals(locale) ? Locale.getDefault() : Locale.forLanguageTag(locale.asString());
+    final Locale language = Types.isNull(locale) ? Locale.getDefault() : Locale.forLanguageTag(locale.asString());
     final int length = str.length();
     final String[] result = new String[length];
     final StringVector strings = stri_prepare_arg_string(str, "str");
@@ -2243,7 +2243,7 @@ public class stringi {
     throw new EvalException("incorrect break iterator option specifier. see ?stri_opts_brkiter");
   }
   private static BreakIterator __open_break_iterator(SEXP opts_brkiter, String defaultType) {
-    if (Null.INSTANCE.equals(opts_brkiter)) {
+    if (Types.isNull(opts_brkiter)) {
       // use default locale
       // use default type
       // use no skip rules
@@ -2354,7 +2354,7 @@ public class stringi {
     }
   }
   private static SEXP __join2_with_collapse(SEXP s1, SEXP s2, SEXP collapse) {
-    if (Null.INSTANCE.equals(collapse)) {
+    if (Types.isNull(collapse)) {
       return stri_join2(s1, s2);
     }
     final StringVector collapsers = stri_prepare_arg_string(collapse, "collapse");

--- a/renjin/org/renjin/cran/stringi/stringi.java
+++ b/renjin/org/renjin/cran/stringi/stringi.java
@@ -3,10 +3,11 @@ package org.renjin.cran.stringi;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
-import java.text.Normalizer;
 import java.text.StringCharacterIterator;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -44,6 +45,7 @@ import com.ibm.icu.lang.UCharacter.HangulSyllableType;
 import com.ibm.icu.lang.UProperty;
 import com.ibm.icu.text.BreakIterator;
 import com.ibm.icu.text.Collator;
+import com.ibm.icu.text.Normalizer2;
 import com.ibm.icu.text.RuleBasedBreakIterator;
 import com.ibm.icu.text.RuleBasedCollator;
 import com.ibm.icu.text.StringSearch;
@@ -231,8 +233,88 @@ public class stringi {
       return new StringArrayVector(result);
     }
   }
-  public static SEXP stri_duplicated(SEXP s1, SEXP s2, SEXP s3) { throw new EvalException("TODO"); }
-  public static SEXP stri_duplicated_any(SEXP s1, SEXP s2, SEXP s3) { throw new EvalException("TODO"); }
+  public static SEXP stri_duplicated(SEXP str, SEXP fromLast, SEXP opts_collator) {
+    final boolean fromEnd = ((AtomicVector) fromLast).getElementAsLogical(0).toBooleanStrict();
+    final int length = str.length();
+    final boolean[] result = new boolean[length];
+    final StringVector strings = stri_prepare_arg_string(str, "str");
+    final RuleBasedCollator collator = __open_collator(opts_collator);
+    final LinkedHashSet<CollatedString> unique = new LinkedHashSet<>();
+
+    boolean no_na = true;
+    if (fromEnd) {
+      for (int i = length - 1; 0 <= i; i--) {
+        if (strings.isElementNA(i)) {
+          result[i] = true;
+          if (no_na) {
+            result[i] = false;
+            no_na = false;
+          }
+        } else {
+          result[i] = !unique.add(new CollatedString(collator, strings.getElementAsString(i)));
+        }
+      }
+    } else {
+      for (int i = 0; i < length; i++) {
+        if (strings.isElementNA(i)) {
+          result[i] = true;
+          if (no_na) {
+            result[i] = false;
+            no_na = false;
+          }
+        } else {
+          result[i] = !unique.add(new CollatedString(collator, strings.getElementAsString(i)));
+        }
+      }
+    }
+
+    return new LogicalArrayVector(result);
+  }
+  public static SEXP stri_duplicated_any(SEXP str, SEXP fromLast, SEXP opts_collator) {
+    final boolean fromEnd = ((AtomicVector) fromLast).getElementAsLogical(0).toBooleanStrict();
+    final int length = str.length();
+    final StringVector strings = stri_prepare_arg_string(str, "str");
+    final RuleBasedCollator collator = __open_collator(opts_collator);
+    final LinkedHashSet<CollatedString> unique = new LinkedHashSet<>();
+
+    int result = 0;
+    boolean no_na = true;
+    if (fromEnd) {
+      for (int i = length - 1; 0 <= i; i--) {
+        if (strings.isElementNA(i)) {
+          if (no_na) {
+            no_na = false;
+          } else {
+            result = i + 1; // 1-based indices
+            break;
+          }
+        } else {
+          if (!unique.add(new CollatedString(collator, strings.getElementAsString(i)))) {
+            result = i + 1; // 1-based indices
+            break;
+          }
+        }
+      }
+    } else {
+      for (int i = 0; i < length; i++) {
+        if (strings.isElementNA(i)) {
+          if (no_na) {
+            no_na = false;
+          } else {
+            result = i + 1; // 1-based indices
+            break;
+          }
+        } else {
+          if (!unique.add(new CollatedString(collator, strings.getElementAsString(i)))) {
+            result = i + 1; // 1-based indices
+            break;
+          }
+        }
+      }
+    }
+
+    return IntVector.valueOf(result);
+  }
   public static SEXP stri_enc_detect(SEXP s1, SEXP s2) { throw new EvalException("TODO"); }
   public static SEXP stri_enc_detect2(SEXP s1, SEXP s2) { throw new EvalException("TODO"); }
   public static SEXP stri_enc_isutf8(SEXP s1) { throw new EvalException("TODO"); }
@@ -768,8 +850,12 @@ public class stringi {
 
     return new IntArrayVector(result);
   }
-  public static SEXP stri_order(SEXP s1, SEXP s2, SEXP s3, SEXP s4) { throw new EvalException("TODO"); }
-  public static SEXP stri_sort(SEXP s1, SEXP s2, SEXP s3, SEXP s4) { throw new EvalException("TODO"); }
+  public static SEXP stri_order(SEXP str, SEXP decreasing, SEXP na_last, SEXP opts_collator) {
+    return __order_or_sort(str, decreasing, na_last, opts_collator, true);
+  }
+  public static SEXP stri_sort(SEXP str, SEXP decreasing, SEXP na_last, SEXP opts_collator) {
+    return __order_or_sort(str, decreasing, na_last, opts_collator, false);
+  }
   public static SEXP stri_pad(SEXP s1, SEXP s2, SEXP s3, SEXP s4, SEXP s5) { throw new EvalException("TODO"); }
   public static StringVector stri_prepare_arg_string(SEXP s, String name) {
     if (s instanceof StringVector) {
@@ -1377,33 +1463,37 @@ public class stringi {
   public static SEXP stri_timezone_info(SEXP s1, SEXP s2, SEXP s3) { throw new EvalException("TODO"); }
   public static SEXP stri_trans_char(SEXP s1, SEXP s2, SEXP s3) { throw new EvalException("TODO"); }
   public static SEXP stri_trans_isnfc(SEXP str) {
-    return __trans_isnf(str, Normalizer.Form.NFC);
+    return __trans_isnf(str, Normalizer2.getNFCInstance());
   }
   public static SEXP stri_trans_isnfd(SEXP str) {
-    return __trans_isnf(str, Normalizer.Form.NFD);
+    return __trans_isnf(str, Normalizer2.getNFDInstance());
   }
   public static SEXP stri_trans_isnfkc(SEXP str) {
-    return __trans_isnf(str, Normalizer.Form.NFKC);
+    return __trans_isnf(str, Normalizer2.getNFKCInstance());
   }
   public static SEXP stri_trans_isnfkd(SEXP str) {
-    return __trans_isnf(str, Normalizer.Form.NFKD);
+    return __trans_isnf(str, Normalizer2.getNFKDInstance());
   }
-  public static SEXP stri_trans_isnfkc_casefold(SEXP s1) { throw new EvalException("TODO"); }
+  public static SEXP stri_trans_isnfkc_casefold(SEXP str) {
+    return __trans_isnf(str, Normalizer2.getNFKCCasefoldInstance());
+  }
   public static SEXP stri_trans_general(SEXP s1, SEXP s2) { throw new EvalException("TODO"); }
   public static SEXP stri_trans_list(SEXP s1, SEXP s0) { throw new EvalException("TODO"); }
   public static SEXP stri_trans_nfc(SEXP str) {
-    return __trans_nf(str, Normalizer.Form.NFC);
+    return __trans_nf(str, Normalizer2.getNFCInstance());
   }
   public static SEXP stri_trans_nfd(SEXP str) {
-    return __trans_nf(str, Normalizer.Form.NFD);
+    return __trans_nf(str, Normalizer2.getNFDInstance());
   }
   public static SEXP stri_trans_nfkc(SEXP str) {
-    return __trans_nf(str, Normalizer.Form.NFKC);
+    return __trans_nf(str, Normalizer2.getNFKCInstance());
   }
   public static SEXP stri_trans_nfkd(SEXP str) {
-    return __trans_nf(str, Normalizer.Form.NFKD);
+    return __trans_nf(str, Normalizer2.getNFKDInstance());
   }
-  public static SEXP stri_trans_nfkc_casefold(SEXP s1) { throw new EvalException("TODO"); }
+  public static SEXP stri_trans_nfkc_casefold(SEXP str) {
+    return __trans_nf(str, Normalizer2.getNFKCCasefoldInstance());
+  }
   public static SEXP stri_trans_totitle(SEXP s1, SEXP s2) { throw new EvalException("TODO"); }
   public static SEXP stri_trans_tolower(SEXP s1, SEXP s2) { throw new EvalException("TODO"); }
   public static SEXP stri_trans_toupper(SEXP s1, SEXP s2) { throw new EvalException("TODO"); }
@@ -1417,7 +1507,31 @@ public class stringi {
     return __trim_left_right(str, pattern, TrimOption.TRAILING);
   }
   public static SEXP stri_unescape_unicode(SEXP s1) { throw new EvalException("TODO"); }
-  public static SEXP stri_unique(SEXP s1, SEXP s2) { throw new EvalException("TODO"); }
+  public static SEXP stri_unique(SEXP str, SEXP opts_collator) {
+    final int length = str.length();
+    final StringVector strings = stri_prepare_arg_string(str, "str");
+    final RuleBasedCollator collator = __open_collator(opts_collator);
+    final LinkedHashSet<CollatedString> unique = new LinkedHashSet<>();
+
+    boolean no_na = true;
+    for (int i = 0; i < length; i++) {
+      if (strings.isElementNA(i)) {
+        if (no_na) {
+          unique.add(new CollatedString(collator, StringVector.NA));
+          no_na = false;
+        }
+      } else {
+        unique.add(new CollatedString(collator, strings.getElementAsString(i)));
+      }
+    }
+    final String[] result = new String[unique.size()];
+    int j = 0;
+    for (CollatedString cs : unique) {
+      result[j++] = cs.str;
+    }
+
+    return new StringArrayVector(result);
+  }
   public static SEXP stri_width(SEXP str) {
     final StringVector strings = stri_prepare_arg_string(str, "str");
     final int length = strings.length();
@@ -1449,6 +1563,32 @@ public class stringi {
     }
   }
 
+  private static final class CollatedString {
+    private final RuleBasedCollator collator;
+    private final String str;
+    private final int hash;
+
+    private CollatedString(RuleBasedCollator collator, String str) {
+      super();
+      this.collator = collator;
+      this.str = str;
+      // return the same hash for decomposed strings and let collator decide for equals
+      this.hash = Normalizer2.getNFKDInstance().normalize(str).toUpperCase().hashCode();
+    }
+    @Override
+    public boolean equals(Object obj) {
+      if (obj != null && obj instanceof CollatedString) {
+        final int cmp = collator.compare(str, ((CollatedString) obj).str);
+        return 0 == cmp;
+      } else {
+        return false;
+      }
+    }
+    @Override
+    public int hashCode() {
+      return hash;
+    }
+  }
   /**
    * Calculate the length of the output vector when applying a vectorized operation on >= 2 vectors
    *
@@ -1848,7 +1988,7 @@ public class stringi {
     /* any other characters have width 1 */
     return 1;
   }
-  private static SEXP __trans_isnf(SEXP str, Normalizer.Form form) {
+  private static SEXP __trans_isnf(SEXP str, Normalizer2 normalizer) {
     final int length = str.length();
     final Logical[] result = new Logical[length];
     final StringVector strings = stri_prepare_arg_string(str, "str");
@@ -1857,13 +1997,13 @@ public class stringi {
       if (strings.isElementNA(i)) {
         result[i] = Logical.NA;
       } else {
-        result[i] = Logical.valueOf(Normalizer.isNormalized(strings.getElementAsString(i), form));
+        result[i] = Logical.valueOf(normalizer.isNormalized(strings.getElementAsString(i)));
       }
     }
 
     return new LogicalArrayVector(result);
   }
-  private static SEXP __trans_nf(SEXP str, Normalizer.Form form) {
+  private static SEXP __trans_nf(SEXP str, Normalizer2 normalizer) {
     final int length = str.length();
     final String[] result = new String[length];
     final StringVector strings = stri_prepare_arg_string(str, "str");
@@ -1872,7 +2012,7 @@ public class stringi {
       if (strings.isElementNA(i)) {
         result[i] = StringVector.NA;
       } else {
-        result[i] = Normalizer.normalize(strings.getElementAsString(i), form);
+        result[i] = normalizer.normalize(strings.getElementAsString(i));
       }
     }
 
@@ -1940,7 +2080,7 @@ public class stringi {
         }
         final String name = names.getElementAsString(i);
         if ("locale".equals(name)) {
-          locale = Locale.forLanguageTag(options.getElementAsString(i));
+          locale = Locale.forLanguageTag(options.getElementAsString(i).replace('_', '-'));
         } else if ("strength".equals(name)) {
           strength = options.getElementAsInt(i) - 1;
           if (strength < Collator.PRIMARY) {
@@ -2271,5 +2411,68 @@ public class stringi {
     final StringVector names = new StringArrayVector(new String[] { "start", "end" });
     builder.setColNames(names);
     return builder.build();
+  }
+  private static SEXP __order_or_sort(SEXP str, SEXP decreasing, SEXP na_last, SEXP opts_collator, boolean order) {
+    final boolean desc = ((AtomicVector) decreasing).getElementAsLogical(0).toBooleanStrict();
+    final Logical lastNA = stri_prepare_arg_logical(na_last, "na_last").getElementAsLogical(0);
+    final boolean isDefinedLastNA = !Logical.NA.equals(lastNA);
+    final int length = str.length();
+    final StringVector strings = stri_prepare_arg_string(str, "str");
+    final RuleBasedCollator collator = __open_collator(opts_collator);
+    final Integer[] ordered = new Integer[length];
+    final LinkedList<Integer> nas = new LinkedList<>();
+
+    int notna = 0;
+    for (int i = 0; i < length; i++) {
+      if (strings.isElementNA(i)) {
+        if (isDefinedLastNA) {
+          nas.add(i);
+        }
+      } else {
+        ordered[notna++] = i;
+      }
+    }
+    Arrays.sort(ordered, new Comparator<Integer>() {
+      @Override
+      public int compare(Integer i1, Integer i2) {
+        final int cmp = collator.compare(strings.getElementAsString(i1), strings.getElementAsString(i2));
+        return desc ? -cmp : cmp;
+      }
+    });
+    if (order) {
+      final int[] result = new int[notna + nas.size()];
+      int j = 0;
+      if (Logical.FALSE.equals(lastNA)) {
+        for (Integer index : nas) {
+          result[j++] = 1 + index; // 1-based indices
+        }
+      }
+      for (int k = 0; k < notna; k++) {
+        result[j++] = 1 + ordered[k]; // 1-based indices
+      }
+      if (Logical.TRUE.equals(lastNA)) {
+        for (Integer index : nas) {
+          result[j++] = 1 + index; // 1-based indices
+        }
+      }
+      return new IntArrayVector(result);
+    } else {
+      final String[] result = new String[notna + nas.size()];
+      int j = 0;
+      if (Logical.FALSE.equals(lastNA)) {
+        for (Integer index : nas) {
+          result[j++] = StringVector.NA;
+        }
+      }
+      for (int k = 0; k < notna; k++) {
+        result[j++] = strings.getElementAsString(ordered[k]);
+      }
+      if (Logical.TRUE.equals(lastNA)) {
+        for (Integer index : nas) {
+          result[j++] = StringVector.NA;
+        }
+      }
+      return new StringArrayVector(result);
+    }
   }
 }


### PR DESCRIPTION
@akbertram 

In this pull request, I introduced a wrapper class to present one column of a `Matrix` (already a wrapper around `Vector`) as if it were an `IntVector`. I am afraid such a facility already exists in your code base, despite the fact that I searched for it and I did not find it.

This pull request contains all the functions that should lead to a green build of `stringr` and make some test in `knitr` pass as well.